### PR TITLE
Fix for breaking changes in tensorflow v2.0

### DIFF
--- a/DQN.ipynb
+++ b/DQN.ipynb
@@ -141,7 +141,8 @@
     "import os\n",
     "import random\n",
     "import gym\n",
-    "import tensorflow as tf\n",
+    "import tensorflow.compat.v1 as tf \n",
+    "tf.disable_v2_behavior() \n",
     "import numpy as np\n",
     "import imageio\n",
     "from skimage.transform import resize"


### PR DESCRIPTION
There are several module-level changes in TensorFlow v2, which breaks the notebook.  This is the recommended fix.